### PR TITLE
[#254] Update design system for creating visual hierarchy

### DIFF
--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -8,9 +8,9 @@ description: This outlines the design system for Digital Training Log and how to
 Don't rely on `font-size` alone to create visual hierarchy. Making a primary element bolder lets you use a more reasonable font size, and often does a better job at communicating its importance. Using a softer color for supporting text instead of a tiny font size makes it clear that the text is secondary while sacrificing less on readability.
 
 These are the three primary text colors in the app
-- A dark color named ink for primary content: `--ink: oklch(0.2098 0.0083 84.59)` this same color is also aliased in `--foreground` which is used by shadcn and `--color-foreground`, the Tailwind classes are `text-foreground` or `color-foreground`.
-- A grey named ink-muted for secondary content: `--ink-muted: oklch(0.5152 0.0119 81.78)`, the Tailwind class: `text-muted-foreground` or `color-muted-foreground`.
-- A lighter grey named ink-faint for tertiary content: `--ink-faint: oklch(0.7203 0.0097 78.27)`. Tailwind class: `text-ink-faint` or `color-ink-faint`
+- A dark color named ink-700 for primary content: `--ink: oklch(0.3 0.008 75)` this same color is also aliased in `--foreground` which is used by shadcn and `--color-foreground`, the Tailwind classes are `text-text-primary`, `text-foreground` or `color-foreground`.
+- A grey named ink-500 for secondary content: `--ink-500: oklch(0.45 0.008 75)`, the Tailwind class: `text-muted-foreground` or `color-muted-foreground`.
+- A lighter grey named ink-300 for tertiary content: `--ink-300: oklch(0.6 0.008 75)`. Tailwind class: `text-text-tertiary` or `color-text-tertiary`
 
 ### Font Weight
 - Use class `font-normal` (`font-weight: 400`) for most text

--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: design
+description: This outlines the design system for Digital Training Log and how to design the experience
+---
+
+## Visual Hierarchy
+
+Don't rely on `font-size` alone to create visual hierarchy. Making a primary element bolder lets you use a more reasonable font size, and often does a better job at communicating its importance. Using a softer color for supporting text instead of a tiny font size makes it clear that the text is secondary while sacrificing less on readability.
+
+These are the three primary text colors in the app
+- A dark color named ink for primary content: `--ink: oklch(0.2098 0.0083 84.59)` this same color is also aliased in `--foreground` which is used by shadcn and `--color-foreground`, the Tailwind classes are `text-foreground` or `color-foreground`.
+- A grey named ink-muted for secondary content: `--ink-muted: oklch(0.5152 0.0119 81.78)`, the Tailwind class: `text-muted-foreground` or `color-muted-foreground`.
+- A lighter grey named ink-faint for tertiary content: `--ink-faint: oklch(0.7203 0.0097 78.27)`. Tailwind class: `text-ink-faint` or `color-ink-faint`
+
+### Font Weight
+- Use class `font-normal` (`font-weight: 400`) for most text
+- Use class `font-bold` for text that should be emphasized (`font-weight: 700`)
+
+Stay away from font weights under 400 for UI work, they can work for headings but are too hard to read at smaller sizes. Instead of reaching for a lighter weight to de-emphasize some text, use a lighter color or smaller font size instead.
+
+Don't use grey text on colored backgrounds. Instead choose the color with the closest hue from the Tailwind color palette and adjust the saturation and lightness until it looks right.
+
+Emphasize by de-emphasizing. Sometimes the main element of an interface isn't standing out enough, but there's nothing to add for emphasis. Figure out how to de-emphasize the elements that are competing with it.
+
+Labels are a last resort
+- You may not need labels at all
+- Clarifying text can be used instead
+- When you need a label treat it as secondary content and make it smaller, lighter, or a lighter font weight
+
+Balance weight and contrast
+- use a lighter color to de-emphasize heavy elements such as icons
+- increasing weight is a great way to add a bit of emphasis to low constrast elements
+
+### Actions
+
+Primary actions should be obvious. Use the default variant from shadcn. Secondary actions should be clear but not prominent. Use the outline or secondary variants from shadcn. Tertiary actions should be discoverable but unobtrusive. Use the ghost variant from shadcn. If a destructive action isn't the primary on the page, it might be better to give it a secondary or tertiary button treatment. Combine this with a confirmation step where the destructive action actually is the primary action, and apply the destructive variant from shadcn there.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,7 +178,7 @@ These principles should inform every feature and UI decision:
 - **Primary accent:** `oklch(0.6045 0.1414 46.33)` (burnt terracotta)
 - **Background:** `oklch(0.9618 0.0086 84.57)` (warm cream)
 - **Ink:** `oklch(0.2098 0.0083 84.59)` (near-black)
-- **Design language:** Editorial minimalism — warm, serious, personal. Not a fitness startup aesthetic.
+- **Design language:** DTL's visual language treats the interface as a digital analog to a paper training journal — a warm, paper-toned background with fine grid or ruled texture, structured data in a clean sans-serif, and freeform commentary in a hand-drawn heading typeface. The aesthetic deliberately departs from generic SaaS polish (soft shadows, uniform radii, pill buttons) to signal a personal tool rather than a commercial product, while keeping quantitative data — distances, splits, dates — rendered with full legibility and trust.
 
 The app icon is a split open-journal mark: left page is a calendar grid (planning), right page is ruled lines with entry bars (logging). The favicon is a minimal 3×3 grid of cells at varying opacity. Both use the accent color on a dark ground.
 
@@ -190,7 +190,10 @@ The app uses semantic CSS variables to theme shadcn components.
 
 |Token|Description|Light Mode Value|Dark Mode Value|
 |---|---|---|---|
-|background|The default app background color|**cream:** `oklch(0.9618 0.0086 84.57)`|**deep-warm-charcoal:** `oklch(0.16 0.008 84.59)`|
+|background|The default app background color|**paper-50:** `oklch(0.99 0.006 75)`|**paper-50-dark:** `oklch(0.2 0.01 75)`|
+|text-primary|The default app text color|**ink-700:** `oklch(0.3 0.008 75)`|**ink-700-dark:** `oklch(0.9 0.006 75)`|
+|text-secondary|The secondary app text color|**ink-500:** `oklch(0.45 0.008 75)`|**ink-500-dark:** `oklch(0.72 0.006 75)`|
+|text-tertiary|The tertiary app text color|**ink-300:** `oklch(0.6 0.008 75)`|**ink-300-dark:** `oklch(0.56 0.006 75)`|
 |foreground|The default app text color|**ink:** `oklch(0.2098 0.0083 84.59)`|**near-cream:** `oklch(0.91 0.0008 84.57)`|
 |primary|High-emphasis actions and brand surfaces|**burnt-terracotta:** `oklch(0.6045 0.1414 46.33)`|**burnt-terracotta:** `oklch(0.6045 0.1414 46.33)`|
 |secondary|Lower-emphasis filled actions and supporting surfaces|**warm-stone:** `oklch(0.72 0.01 84.59)`|**dark stone:** `oklch(0.24 0.009 84.59)`|

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -30,6 +30,10 @@
 
   /* semantic color tokens */
   --color-background: oklch(var(--background));
+  --color-text-primary: oklch(var(--text-primary));
+  --color-text-secondary: oklch(var(--text-secondary));
+  --color-text-tertiary: oklch(var(--text-tertiary));
+
   --color-foreground: oklch(var(--foreground));
   --color-border: oklch(var(--border));
   --color-border-emphasis: oklch(var(--border-emphasis));
@@ -111,18 +115,19 @@
 }
 
 :root {
-  /* raw tokens */
+  /* raw light mode tokens */
+  --paper-50: 0.99 0.006 75; /* #fefbf7 */
+  --ink-700: 0.3 0.008 75; /* #302d29 */
+  --ink-500: 0.45 0.008 75; /* #585550 */
+  --ink-300: 0.6 0.008 75; /* #83807b */
+
   --beige: 0.9297 0.0161 82.79; /* #ede7dc */
   --black: 0 0 0; /* #ffffff */
   --blush-rose: 0.7794 0.0741 23.07; /* #e3a5a1 */
   --burnt-terracotta: 0.6045 0.1414 46.33; /* #c4622d */
-  --cream: 0.9618 0.0086 84.57; /* #f5f2ec */
   --dark-surface: 0.18 0.006 84.59; /* #13110f */
   --dark-muted: 0.29 0.008 84.59; /* #2d2b27 */
   --destructive-red: 0.577 0.245 27.325; /* #e7000b */
-  --ink: 0.2098 0.0083 84.59; /* #1a1814 */
-  --ink-faint: 0.7203 0.0097 78.27; /* #a8a49e */
-  --ink-muted: 0.5152 0.0119 81.78; /* #6b6760 */
   --light-beige: 0.9395 0.0165 79.35; /* #f1eadf */
   --light-olive: 0.7392 0.0353 135.59; /* #a1b09a */
   --lighter-red: 0.704 0.191 22.216; /* #ff6467 */
@@ -130,37 +135,40 @@
   --olive: 0.667 0.0545 127.31; /* #8b9b77 */
   --taupe: 0.72 0.03 60; /* #b3a192 */
   --terracotta: 0.6535 0.1054 46.31; /* #c57b57 */
-  --warm-white: 0.9939 0.0082 91.48; /* #fffdf7 */
 
   /* semantic typography tokens */
   --emphasis-heading: var(--near-cream);
 
   /* semantic tokens */
-  --background: var(--cream);
-  --foreground: var(--ink);
-  --border: var(--ink) / 0.12;
+  --background: var(--paper-50);
+  --text-primary: var(--ink-700);
+  --text-secondary: var(--ink-500);
+  --text-tertiary: var(--ink-300);
+
+  --foreground: var(--text-primary);
+  --border: var(--text-primary) / 0.12;
   --border-emphasis: var(--near-cream) / 0.2;
   --primary: var(--burnt-terracotta);
   --primary-foreground: var(--black);
   --secondary: var(--light-olive);
-  --secondary-foreground: var(--ink);
+  --secondary-foreground: var(--text-primary);
   --accent: var(--light-beige);
-  --accent-foreground: var(--ink);
+  --accent-foreground: var(--text-primary);
   --muted: var(--beige);
-  --muted-foreground: var(--ink-muted);
-  --emphasis: var(--ink);
-  --emphasis-foreground: var(--ink-faint);
+  --muted-foreground: var(--text-secondary);
+  --emphasis: var(--text-primary);
+  --emphasis-foreground: var(--text-tertiary);
   --destructive: var(--destructive-red);
 
   /* component specific semantic tokens */
-  --input: var(--ink) / 0.18;
+  --input: var(--text-primary) / 0.18;
   --ring: var(--burnt-terracotta);
 
-  --card: var(--warm-white);
-  --card-foreground: var(--ink);
+  --card: var(--background);
+  --card-foreground: var(--text-primary);
 
-  --popover: var(--warm-white);
-  --popover-foreground: var(--ink);
+  --popover: var(--background);
+  --popover-foreground: var(--text-primary);
 
   --chart-1: oklch(0.87 0 0);
   --chart-2: oklch(0.556 0 0);
@@ -183,26 +191,26 @@
 }
 
 .dark {
+  /* raw dark mode tokens */
+  --paper-50: 0.2 0.01 75; /* #191511 */
+  --ink-700: 0.9 0.006 75; /* #dfdcd8 */
+  --ink-500: 0.72 0.006 75; /* #a6a3a0 */
+  --ink-300: 0.56 0.006 75; /* #767370 */
+
   /* semantic tokens */
-  --background: var(--ink);
-  --foreground: var(--near-cream);
   --border: var(--near-cream) / 0.18;
   --border-emphasis: var(--near-cream);
 
   --primary: var(--terracotta);
-  --primary-foreground: var(--ink);
 
   --secondary: var(--olive);
   --secondary-foreground: var(--black);
 
   --muted: var(--dark-muted);
-  --muted-foreground: var(--ink-faint);
 
   --accent: var(--beige);
-  --accent-foreground: var(--ink);
 
   --emphasis: var(--dark-surface);
-  --emphasis-foreground: var(--ink-faint);
   --emphasis-heading: var(--near-cream);
 
   --destructive: var(--lighter-red);

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -79,6 +79,23 @@
   --radius-2xl: calc(var(--radius) * 1.8);
   --radius-3xl: calc(var(--radius) * 2.2);
   --radius-4xl: calc(var(--radius) * 2.6);
+
+  --grid-paper:
+    linear-gradient(to right, oklch(var(--ink) / 0.04) 1px, transparent 1px),
+    linear-gradient(to bottom, oklch(var(--ink) / 0.04) 1px, transparent 1px);
+  --grid-paper-dark:
+    linear-gradient(
+      to right,
+      oklch(var(--near-cream) / 0.04) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      to bottom,
+      oklch(var(--near-cream) / 0.04) 1px,
+      transparent 1px
+    );
+  --grid-md: 24px 24px;
+
   --animate-fade-up: fadeUp 0.7s ease both;
 
   @keyframes fadeUp {


### PR DESCRIPTION
Does the following:
- Updates the design system tokens related to visual hierarchy
  - `--background` which is based on `--paper-50`
  - `--text-primary` which is based on `--ink-700`
  - `--text-secondary` which is based on `--ink-500`
  - `--text-tertiary` which is based on `--ink-300`
- Dark mode now overrides the raw tokens (`--paper-50`, `--ink-700`, etc)
- Refines the design language to move towards a slightly new aesthetic
- Starts a design skill that codifies the heuristics from Refactoring UI